### PR TITLE
Remove the host_id for list_hosts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# 0.4.3
+
+- Remove `host_id` as a parameter to fix the list hosts action
+
 # 0.4.2
 
 - Minor linting fix

--- a/actions/list_hosts.py
+++ b/actions/list_hosts.py
@@ -2,7 +2,7 @@ from lib.mmonit import MmonitBaseAction
 
 
 class MmonitListHosts(MmonitBaseAction):
-    def run(self, host_id):
+    def run(self):
         self.login()
         req = self.session.get("{}/admin/hosts/list".format(self.url))
 

--- a/pack.yaml
+++ b/pack.yaml
@@ -5,7 +5,7 @@ description : mmonit integrations
 keywords:
   - monitoring
   - mmonit
-version: 0.4.2
+version: 0.4.3
 python_versions:
   - "2"
   - "3"


### PR DESCRIPTION
The `host_id` is not in the action parameters and not used in the `run()` function.